### PR TITLE
fix(wslink): update min wslink version to 1.2.0

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -27,7 +27,7 @@ keywords =
 
 [options]
 packages = find:
-install_requires = wslink>=1.0.7
+install_requires = wslink>=1.2.0
 include_package_data = True
 package_dir =
     =src


### PR DESCRIPTION
Wslink 1.2.0 is required for the current py-web-vue.
